### PR TITLE
fix: get default repo branch name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@zackiles/cursor-workbench",
-  "version": "0.0.1",
+  "name": "cursor-workbench",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@zackiles/cursor-workbench",
-      "version": "0.0.1",
+      "name": "cursor-workbench",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "marked": "^12.0.2",

--- a/src/common/registryManager.ts
+++ b/src/common/registryManager.ts
@@ -821,12 +821,15 @@ class RegistryManager {
         '.cursor'
       ])
 
-      // Step 3: Checkout the main branch to populate only .cursor directory
+      // Step 3: Get the default branch
+      const defaultBranch = await this.getDefaultBranch(repoPath)
+
+      // Step 4: Checkout the main branch to populate only .cursor directory
       await this.executeGitCommandDirect('git', [
         '-C',
         repoPath,
         'checkout',
-        'main'
+        defaultBranch
       ])
 
       // Verify .cursor directory exists
@@ -886,6 +889,16 @@ class RegistryManager {
         reject(new Error(`Git command failed: ${error.message}`))
       })
     })
+  }
+
+  private async getDefaultBranch(repoPath: string): Promise<string> {
+    const branch = await this.executeGitCommandDirect("git", [
+      "-C",
+      repoPath,
+      "symbolic-ref",
+      "refs/remotes/origin/HEAD",
+    ]);
+    return branch.trim().split("/").pop() || "main";
   }
 
   private async removeDirectory(dirPath: string): Promise<void> {


### PR DESCRIPTION
When checking out a repo the extension was defaulting to the `main` branch. We now analyze the repository and get the base branch dynamically to ensure that if the base is `master` or something else custom, the repo is checked out correctly. 