### PR TITLE
fix: output popping up in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-workbench",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-workbench",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "marked": "^12.0.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,6 +170,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     setTimeout(() => {
       logger.log('Opening Developer Tools in development mode')
+      logger.show()
       vscode.commands.executeCommand(
         'workbench.action.webview.openDeveloperTools'
       )
@@ -276,7 +277,7 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   )
 
-  logger.show()
+ 
 }
 
 export function deactivate() {}


### PR DESCRIPTION
The VS Code/Cursor Output window was popping up for all users whenever a new window was opened, which was very annoying. I've fixed it to only appear in dev mode (as the logs suggest was the original intention). 